### PR TITLE
DX12 Compute Shader

### DIFF
--- a/Engine/common_dx/include/DXComputeBuffer.hpp
+++ b/Engine/common_dx/include/DXComputeBuffer.hpp
@@ -14,10 +14,7 @@ class DXRenderTarget;
 class DXComputeBuffer
 {
 public:
-	DXComputeBuffer(
-		/*const ComPtr<ID3D12Device>& device,
-		const ComPtr<ID3D12CommandQueue>& commandQueue,
-		const std::vector<uint32_t>* indices*/) = default;
+	DXComputeBuffer() = default;
 	~DXComputeBuffer() = default;
 
 	DXComputeBuffer(const DXComputeBuffer&) = delete;
@@ -34,8 +31,6 @@ public:
 	);
 	void PostProcess(
 		const ComPtr<ID3D12GraphicsCommandList>& commandList,
-		/*const ComPtr<ID3D12Device>& device,
-		int width, int height,*/
 		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
 		const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
 		const ComPtr<ID3D12Resource>& renderTarget);

--- a/Engine/common_dx/include/DXComputeBuffer.hpp
+++ b/Engine/common_dx/include/DXComputeBuffer.hpp
@@ -29,11 +29,18 @@ public:
 		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
 		const std::unique_ptr<DXRenderTarget>& renderTarget
 	);
+	void OnResize(
+		const ComPtr<ID3D12Device>& device,
+		int width, int height,
+		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
+		const std::unique_ptr<DXRenderTarget>& renderTarget
+	);
 	void PostProcess(
 		const ComPtr<ID3D12GraphicsCommandList>& commandList,
 		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
 		const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
-		const ComPtr<ID3D12Resource>& renderTarget);
+		const ComPtr<ID3D12Resource>& renderTarget
+	);
 private:
 	ComPtr<ID3D12RootSignature> m_computeRootSignature;
 	ComPtr<ID3D12PipelineState> m_computePipelineState;

--- a/Engine/common_dx/include/DXComputeBuffer.hpp
+++ b/Engine/common_dx/include/DXComputeBuffer.hpp
@@ -1,0 +1,54 @@
+//Author: JEYOON YU
+//Project: CubeEngine
+//File: DXComputeBuffer.hpp
+#pragma once
+#include <directx/d3dx12.h>
+#include <wrl.h>
+
+#include <filesystem>
+
+using Microsoft::WRL::ComPtr;
+
+class DXRenderTarget;
+
+class DXComputeBuffer
+{
+public:
+	DXComputeBuffer(
+		/*const ComPtr<ID3D12Device>& device,
+		const ComPtr<ID3D12CommandQueue>& commandQueue,
+		const std::vector<uint32_t>* indices*/) = default;
+	~DXComputeBuffer() = default;
+
+	DXComputeBuffer(const DXComputeBuffer&) = delete;
+	DXComputeBuffer& operator=(const DXComputeBuffer&) = delete;
+	DXComputeBuffer(const DXComputeBuffer&&) = delete;
+	DXComputeBuffer& operator=(const DXComputeBuffer&&) = delete;
+
+	void InitComputeBuffer(
+		const ComPtr<ID3D12Device>& device,
+		const std::filesystem::path& computePath,
+		int width, int height,
+		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
+		const std::unique_ptr<DXRenderTarget>& renderTarget
+	);
+	void PostProcess(
+		const ComPtr<ID3D12GraphicsCommandList>& commandList,
+		/*const ComPtr<ID3D12Device>& device,
+		int width, int height,*/
+		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
+		const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
+		const ComPtr<ID3D12Resource>& renderTarget);
+private:
+	ComPtr<ID3D12RootSignature> m_computeRootSignature;
+	ComPtr<ID3D12PipelineState> m_computePipelineState;
+
+	ComPtr<ID3D12Resource> m_postProcessTexture;
+
+	CD3DX12_CPU_DESCRIPTOR_HANDLE m_postProcessInputSrvCpuHandle;
+	CD3DX12_GPU_DESCRIPTOR_HANDLE m_postProcessInputSrvGpuHandle;
+	CD3DX12_CPU_DESCRIPTOR_HANDLE m_postProcessOutputUavCpuHandle;
+	CD3DX12_GPU_DESCRIPTOR_HANDLE m_postProcessOutputUavGpuHandle;
+
+	int m_width, m_height;
+};

--- a/Engine/common_dx/include/DXComputeBuffer.hpp
+++ b/Engine/common_dx/include/DXComputeBuffer.hpp
@@ -40,7 +40,7 @@ public:
 		const ComPtr<ID3D12DescriptorHeap>& srvHeap,
 		const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
 		const ComPtr<ID3D12Resource>& renderTarget
-	);
+	) const;
 private:
 	ComPtr<ID3D12RootSignature> m_computeRootSignature;
 	ComPtr<ID3D12PipelineState> m_computePipelineState;

--- a/Engine/common_dx/source/DXComputeBuffer.cpp
+++ b/Engine/common_dx/source/DXComputeBuffer.cpp
@@ -10,14 +10,6 @@
 
 #include <stdexcept>
 
-//DXComputeBuffer::DXComputeBuffer(
-//	const ComPtr<ID3D12Device>& device,
-//	const ComPtr<ID3D12CommandQueue>& commandQueue,
-//	const std::vector<uint32_t>* indices) : m_commandQueue(commandQueue)
-//{
-//	InitComputeBuffer(device, indices);
-//}
-
 void DXComputeBuffer::InitComputeBuffer(
 	const ComPtr<ID3D12Device>& device,
 	const std::filesystem::path& computePath,
@@ -150,8 +142,6 @@ void DXComputeBuffer::InitComputeBuffer(
 
 void DXComputeBuffer::PostProcess(
 	const ComPtr<ID3D12GraphicsCommandList>& commandList,
-	/*const ComPtr<ID3D12Device>& device,
-	int width, int height,*/
 	const ComPtr<ID3D12DescriptorHeap>& srvHeap,
 	const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
 	const ComPtr<ID3D12Resource>& renderTarget)

--- a/Engine/common_dx/source/DXComputeBuffer.cpp
+++ b/Engine/common_dx/source/DXComputeBuffer.cpp
@@ -49,7 +49,7 @@ void DXComputeBuffer::InitComputeBuffer(
 	DXHelper::ThrowIfFailed(device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
 	DXHelper::ThrowIfFailed(m_computeRootSignature->SetName(L"Compute Root Signature"));
 
-	// Create Pipeline State Object
+	// Compile Compute Shader
 #ifdef _DEBUG
 	UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
@@ -87,57 +87,12 @@ void DXComputeBuffer::InitComputeBuffer(
 	psoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
 	psoDesc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
 
-	// Create the Pipeline State Object (PSO)
+	// Create Pipeline State Object (PSO)
 	DXHelper::ThrowIfFailed(device->CreateComputePipelineState(&psoDesc, IID_PPV_ARGS(&m_computePipelineState)));
 	DXHelper::ThrowIfFailed(m_computePipelineState->SetName(L"Compute PSO"));
 
-	//m_texture.Reset();
-
-	auto textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(
-		DXGI_FORMAT_R8G8B8A8_UNORM,
-		m_width,
-		m_height,
-		1, 0, 1, 0,
-		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
-	);
-
-	CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
-	DXHelper::ThrowIfFailed(device->CreateCommittedResource(
-		&heapProps,
-		D3D12_HEAP_FLAG_NONE,
-		&textureDesc,
-		D3D12_RESOURCE_STATE_COMMON,
-		nullptr,
-		IID_PPV_ARGS(&m_postProcessTexture)
-	));
-	m_postProcessTexture->SetName(L"Post Process Output Texture");
-
-	UINT descriptorSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-	CD3DX12_CPU_DESCRIPTOR_HANDLE srvHeapStart(srvHeap->GetCPUDescriptorHandleForHeapStart());
-	CD3DX12_GPU_DESCRIPTOR_HANDLE srvGpuHeapStart(srvHeap->GetGPUDescriptorHandleForHeapStart());
-
-	constexpr int postProcessDescriptorOffset = 505;
-
-	m_postProcessInputSrvCpuHandle = srvHeapStart;
-	m_postProcessInputSrvCpuHandle.Offset(postProcessDescriptorOffset, descriptorSize);
-	m_postProcessInputSrvGpuHandle = srvGpuHeapStart;
-	m_postProcessInputSrvGpuHandle.Offset(postProcessDescriptorOffset, descriptorSize);
-
-	D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-	srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-	srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMS;
-	device->CreateShaderResourceView(renderTarget->GetMSAARenderTarget().Get(), &srvDesc, m_postProcessInputSrvCpuHandle);
-
-	m_postProcessOutputUavCpuHandle = srvHeapStart;
-	m_postProcessOutputUavCpuHandle.Offset(postProcessDescriptorOffset + 1, descriptorSize);
-	m_postProcessOutputUavGpuHandle = srvGpuHeapStart;
-	m_postProcessOutputUavGpuHandle.Offset(postProcessDescriptorOffset + 1, descriptorSize);
-
-	D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-	uavDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-	device->CreateUnorderedAccessView(m_postProcessTexture.Get(), nullptr, &uavDesc, m_postProcessOutputUavCpuHandle);
+	// Initialize output texture, descriptors
+	OnResize(device, m_width, m_height, srvHeap, renderTarget);
 }
 
 void DXComputeBuffer::OnResize(
@@ -155,7 +110,7 @@ void DXComputeBuffer::OnResize(
 		DXGI_FORMAT_R8G8B8A8_UNORM,
 		m_width,
 		m_height,
-		1, 0, 1, 0,
+		1, 1, 1, 0,
 		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
 	);
 
@@ -227,6 +182,13 @@ void DXComputeBuffer::PostProcess(
 
 	commandList->CopyResource(renderTarget.Get(), m_postProcessTexture.Get());
 
-	CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET);
-	commandList->ResourceBarrier(1, &barrier);
+	//CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	//commandList->ResourceBarrier(1, &barrier);
+
+	CD3DX12_RESOURCE_BARRIER finalBarriers[] = {
+		CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET),
+		CD3DX12_RESOURCE_BARRIER::Transition(dxRenderTarget->GetMSAARenderTarget().Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RESOLVE_SOURCE),
+		CD3DX12_RESOURCE_BARRIER::Transition(m_postProcessTexture.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COMMON)
+	};
+	commandList->ResourceBarrier(_countof(finalBarriers), finalBarriers);
 }

--- a/Engine/common_dx/source/DXComputeBuffer.cpp
+++ b/Engine/common_dx/source/DXComputeBuffer.cpp
@@ -1,0 +1,183 @@
+//Author: JEYOON YU
+//Project: CubeEngine
+//File: DXComputeBuffer.cpp
+#include "DXComputeBuffer.hpp"
+#include "DXHelper.hpp"
+#include "DXRenderTarget.hpp"
+
+#include <d3d12.h>
+#include <d3dcompiler.h>
+
+#include <stdexcept>
+
+//DXComputeBuffer::DXComputeBuffer(
+//	const ComPtr<ID3D12Device>& device,
+//	const ComPtr<ID3D12CommandQueue>& commandQueue,
+//	const std::vector<uint32_t>* indices) : m_commandQueue(commandQueue)
+//{
+//	InitComputeBuffer(device, indices);
+//}
+
+void DXComputeBuffer::InitComputeBuffer(
+	const ComPtr<ID3D12Device>& device,
+	const std::filesystem::path& computePath,
+	int width, int height,
+	const ComPtr<ID3D12DescriptorHeap>& srvHeap,
+	const std::unique_ptr<DXRenderTarget>& renderTarget
+)
+{
+	m_width = width;
+	m_height = height;
+
+	// Create Root Signature
+	CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+	// Input Texture (t0)
+	ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+	// Outpyt Texture (u0)
+	ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
+
+	CD3DX12_ROOT_PARAMETER1 rootParameter;
+	rootParameter.InitAsDescriptorTable(2, ranges);
+
+	CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC computeRootSignatureDesc;
+	computeRootSignatureDesc.Init_1_1(
+		1, &rootParameter,
+		0, nullptr,
+		D3D12_ROOT_SIGNATURE_FLAG_NONE
+	);
+
+	ComPtr<ID3DBlob> signature, error;
+	HRESULT hr = D3D12SerializeVersionedRootSignature(&computeRootSignatureDesc, &signature, &error);
+	if (FAILED(hr))
+	{
+		if (error) OutputDebugStringA(static_cast<const char*>(error->GetBufferPointer()));
+		throw std::runtime_error("Failed to serialize compute root signature.");
+	}
+
+	DXHelper::ThrowIfFailed(device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&m_computeRootSignature)));
+	DXHelper::ThrowIfFailed(m_computeRootSignature->SetName(L"Compute Root Signature"));
+
+	// Create Pipeline State Object
+#ifdef _DEBUG
+	UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+#else
+	UINT compileFlags = 0;
+#endif
+
+	ComPtr<ID3DBlob> errorMessages;
+
+	ComPtr<ID3DBlob> computeShader;
+	hr = D3DCompileFromFile(
+		computePath.c_str(),
+		nullptr,
+		nullptr,
+		"computeMain",
+		"cs_5_1",
+		compileFlags,
+		0,
+		&computeShader,
+		&errorMessages
+	);
+	if (FAILED(hr))
+	{
+		if (errorMessages)
+		{
+			const char* string = static_cast<const char*>(errorMessages->GetBufferPointer());
+			OutputDebugStringA("Compute Shader Compilation Error:\n");
+			OutputDebugStringA(string);
+		}
+		throw std::runtime_error("Failed to compile compute shader.");
+	}
+
+	// Create Pipeline State Object (PSO) description
+	D3D12_COMPUTE_PIPELINE_STATE_DESC psoDesc = {};
+	psoDesc.pRootSignature = m_computeRootSignature.Get();
+	psoDesc.CS = CD3DX12_SHADER_BYTECODE(computeShader.Get());
+	psoDesc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
+
+	// Create the Pipeline State Object (PSO)
+	DXHelper::ThrowIfFailed(device->CreateComputePipelineState(&psoDesc, IID_PPV_ARGS(&m_computePipelineState)));
+	DXHelper::ThrowIfFailed(m_computePipelineState->SetName(L"Compute PSO"));
+
+	//m_texture.Reset();
+
+	auto textureDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+		DXGI_FORMAT_R8G8B8A8_UNORM,
+		m_width,
+		m_height,
+		1, 0, 1, 0,
+		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
+	);
+
+	CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+	DXHelper::ThrowIfFailed(device->CreateCommittedResource(
+		&heapProps,
+		D3D12_HEAP_FLAG_NONE,
+		&textureDesc,
+		D3D12_RESOURCE_STATE_COMMON,
+		nullptr,
+		IID_PPV_ARGS(&m_postProcessTexture)
+	));
+	m_postProcessTexture->SetName(L"Post Process Output Texture");
+
+	UINT descriptorSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+	CD3DX12_CPU_DESCRIPTOR_HANDLE srvHeapStart(srvHeap->GetCPUDescriptorHandleForHeapStart());
+	CD3DX12_GPU_DESCRIPTOR_HANDLE srvGpuHeapStart(srvHeap->GetGPUDescriptorHandleForHeapStart());
+
+	constexpr int postProcessDescriptorOffset = 505;
+
+	m_postProcessInputSrvCpuHandle = srvHeapStart;
+	m_postProcessInputSrvCpuHandle.Offset(postProcessDescriptorOffset, descriptorSize);
+	m_postProcessInputSrvGpuHandle = srvGpuHeapStart;
+	m_postProcessInputSrvGpuHandle.Offset(postProcessDescriptorOffset, descriptorSize);
+
+	D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+	srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+	srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMS;
+	device->CreateShaderResourceView(renderTarget->GetMSAARenderTarget().Get(), &srvDesc, m_postProcessInputSrvCpuHandle);
+
+	m_postProcessOutputUavCpuHandle = srvHeapStart;
+	m_postProcessOutputUavCpuHandle.Offset(postProcessDescriptorOffset + 1, descriptorSize);
+	m_postProcessOutputUavGpuHandle = srvGpuHeapStart;
+	m_postProcessOutputUavGpuHandle.Offset(postProcessDescriptorOffset + 1, descriptorSize);
+
+	D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+	uavDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+	device->CreateUnorderedAccessView(m_postProcessTexture.Get(), nullptr, &uavDesc, m_postProcessOutputUavCpuHandle);
+}
+
+void DXComputeBuffer::PostProcess(
+	const ComPtr<ID3D12GraphicsCommandList>& commandList,
+	/*const ComPtr<ID3D12Device>& device,
+	int width, int height,*/
+	const ComPtr<ID3D12DescriptorHeap>& srvHeap,
+	const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
+	const ComPtr<ID3D12Resource>& renderTarget)
+{
+	commandList->SetPipelineState(m_computePipelineState.Get());
+	commandList->SetComputeRootSignature(m_computeRootSignature.Get());
+
+	CD3DX12_RESOURCE_BARRIER barriers[2];
+	barriers[0] = CD3DX12_RESOURCE_BARRIER::Transition(dxRenderTarget->GetMSAARenderTarget().Get(), D3D12_RESOURCE_STATE_RESOLVE_SOURCE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+	barriers[1] = CD3DX12_RESOURCE_BARRIER::Transition(m_postProcessTexture.Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+	commandList->ResourceBarrier(2, barriers);
+
+	ID3D12DescriptorHeap* ppHeaps[] = { srvHeap.Get() };
+	commandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+	commandList->SetComputeRootDescriptorTable(0, m_postProcessInputSrvGpuHandle);
+
+	UINT dispatchX = (m_width + 7) / 8;
+	UINT dispatchY = (m_height + 7) / 8;
+	commandList->Dispatch(dispatchX, dispatchY, 1);
+
+	barriers[0] = CD3DX12_RESOURCE_BARRIER::Transition(m_postProcessTexture.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+	barriers[1] = CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_COPY_DEST);
+	commandList->ResourceBarrier(2, barriers);
+
+	commandList->CopyResource(renderTarget.Get(), m_postProcessTexture.Get());
+
+	CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	commandList->ResourceBarrier(1, &barrier);
+}

--- a/Engine/common_dx/source/DXComputeBuffer.cpp
+++ b/Engine/common_dx/source/DXComputeBuffer.cpp
@@ -158,7 +158,7 @@ void DXComputeBuffer::PostProcess(
 	const ComPtr<ID3D12DescriptorHeap>& srvHeap,
 	const std::unique_ptr<DXRenderTarget>& dxRenderTarget,
 	const ComPtr<ID3D12Resource>& renderTarget
-)
+) const
 {
 	commandList->SetPipelineState(m_computePipelineState.Get());
 	commandList->SetComputeRootSignature(m_computeRootSignature.Get());
@@ -181,9 +181,6 @@ void DXComputeBuffer::PostProcess(
 	commandList->ResourceBarrier(2, barriers);
 
 	commandList->CopyResource(renderTarget.Get(), m_postProcessTexture.Get());
-
-	//CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET);
-	//commandList->ResourceBarrier(1, &barrier);
 
 	CD3DX12_RESOURCE_BARRIER finalBarriers[] = {
 		CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET),

--- a/Engine/common_dx/source/DXPipeLine.cpp
+++ b/Engine/common_dx/source/DXPipeLine.cpp
@@ -123,5 +123,5 @@ DXPipeLine::DXPipeLine(
 
 	// Create the Pipeline State Object (PSO)
 	DXHelper::ThrowIfFailed(device->CreateGraphicsPipelineState(&psoDesc,IID_PPV_ARGS(&m_pipelineState)));
-	DXHelper::ThrowIfFailed(m_pipelineState->SetName(L"Compute PSO"));
+	DXHelper::ThrowIfFailed(m_pipelineState->SetName(L"PSO"));
 }

--- a/Engine/common_dx/source/DXPipeLine.cpp
+++ b/Engine/common_dx/source/DXPipeLine.cpp
@@ -121,7 +121,7 @@ DXPipeLine::DXPipeLine(
 	psoDesc.RTVFormats[0] = rtvFormat;
 	psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
 
-	// Create the Pipeline State Object (PSO)
+	// Create Pipeline State Object (PSO)
 	DXHelper::ThrowIfFailed(device->CreateGraphicsPipelineState(&psoDesc,IID_PPV_ARGS(&m_pipelineState)));
 	DXHelper::ThrowIfFailed(m_pipelineState->SetName(L"PSO"));
 }

--- a/Engine/common_dx/source/DXPipeLine.cpp
+++ b/Engine/common_dx/source/DXPipeLine.cpp
@@ -123,4 +123,5 @@ DXPipeLine::DXPipeLine(
 
 	// Create the Pipeline State Object (PSO)
 	DXHelper::ThrowIfFailed(device->CreateGraphicsPipelineState(&psoDesc,IID_PPV_ARGS(&m_pipelineState)));
+	DXHelper::ThrowIfFailed(m_pipelineState->SetName(L"Compute PSO"));
 }

--- a/Engine/include/DXRenderManager.hpp
+++ b/Engine/include/DXRenderManager.hpp
@@ -16,6 +16,7 @@
 #include "DXImGuiManager.hpp"
 #include "DXSkybox.hpp"
 #include "DXRenderTarget.hpp"
+#include "DXComputeBuffer.hpp"
 
 #include "BasicComponents/Sprite.hpp"
 
@@ -47,7 +48,7 @@ public:
 private:
 	// Initialize DirectX 12 components
 	void GetHardwareAdapter(IDXGIFactory1* pFactory, IDXGIAdapter1** ppAdapter);
-	void CreateRootSignature(ComPtr<ID3D12RootSignature>& rootSignature, const std::vector<CD3DX12_ROOT_PARAMETER1>& rootParameters);
+	void CreateRootSignature(ComPtr<ID3D12RootSignature>& rootSignature, const std::vector<CD3DX12_ROOT_PARAMETER1>& rootParameters) const;
 	void MoveToNextFrame();
 
 	struct LiveObjectReporter
@@ -99,6 +100,9 @@ private:
 	// MSAA
 	// Depth
 	std::unique_ptr<DXRenderTarget> m_renderTarget;
+
+	// Compute Shader
+	DXComputeBuffer m_computeBuffer;
 
 #if USE_NSIGHT_AFTERMATH
 	// App-managed marker functionality

--- a/Engine/include/DXRenderManager.hpp
+++ b/Engine/include/DXRenderManager.hpp
@@ -102,7 +102,7 @@ private:
 	std::unique_ptr<DXRenderTarget> m_renderTarget;
 
 	// Compute Shader
-	DXComputeBuffer m_computeBuffer;
+	std::unique_ptr<DXComputeBuffer> m_computeBuffer;
 
 #if USE_NSIGHT_AFTERMATH
 	// App-managed marker functionality

--- a/Engine/shaders/hlsl/Compute.compute.hlsl
+++ b/Engine/shaders/hlsl/Compute.compute.hlsl
@@ -1,0 +1,31 @@
+#pragma pack_matrix(column_major)
+#ifdef SLANG_HLSL_ENABLE_NVAPI
+#include "nvHLSLExtns.h"
+#endif
+
+#ifndef __DXC_VERSION_MAJOR
+// warning X3557: loop doesn't seem to do anything, forcing loop to unroll
+#pragma warning(disable : 3557)
+#endif
+
+
+#line 8 "Compute.slang"
+Texture2DMS<float4 > g_input_0 : register(t0);
+
+
+#line 9
+RWTexture2D<float4 > g_output_0 : register(u0);
+
+
+#line 16
+[numthreads(8, 8, 1)]
+void computeMain(uint3 dispatchThreadID_0 : SV_DispatchThreadID)
+{
+
+#line 18
+    uint2 _S1 = dispatchThreadID_0.xy;
+
+    g_output_0[_S1] = float4(1.0 - g_input_0.Load(int2(_S1), int(0)).xyz, 1.0);
+    return;
+}
+

--- a/Engine/shaders/slang/Compute.slang
+++ b/Engine/shaders/slang/Compute.slang
@@ -1,0 +1,23 @@
+#extension GL_EXT_nonuniform_qualifier : enable
+
+#define MAX_TEXTURES 500
+#define MAX_LIGHTS 10
+#define PI 3.14159265358979323846f
+
+#if defined(__hlsl__)
+Texture2DMS<float4> g_input : register(t0);
+RWTexture2D<float4> g_output : register(u0);
+#else
+Texture2D<float4> g_input : register(t0);
+RWTexture2D<float4> g_output : register(u0);
+#endif
+
+[numthreads(8, 8, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // float4 originalColor = g_input.Load(dispatchThreadID.xy, 0);
+    // float4 invertedColor = float4(1.f - originalColor.rgb, 1.f);
+    // g_output[dispatchThreadID.xy] = invertedColor;
+
+    g_output[dispatchThreadID.xy] = float4(1.f,0.f,0.f,1.f);
+}

--- a/Engine/source/DXRenderManager.cpp
+++ b/Engine/source/DXRenderManager.cpp
@@ -115,6 +115,7 @@ void DXRenderManager::Initialize(SDL_Window* window)
 	m_renderTarget = std::make_unique<DXRenderTarget>(m_device, window);
 
 	D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
+	// 500 for Sprites, 5 for Skybox, 2 for Compute Shader
 	srvHeapDesc.NumDescriptors = 507;
 	srvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
 	srvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
@@ -281,7 +282,8 @@ void DXRenderManager::Initialize(SDL_Window* window)
 	pointLightUniformBuffer = new DXConstantBuffer<PointLightBatch>(m_device, frameCount);
 
 	// Initialize for compute shader
-	m_computeBuffer.InitComputeBuffer(m_device, "../Engine/shaders/hlsl/Compute.compute.hlsl", 1280, 720, m_srvHeap, m_renderTarget);
+	m_computeBuffer = std::make_unique<DXComputeBuffer>();
+	m_computeBuffer->InitComputeBuffer(m_device, "../Engine/shaders/hlsl/Compute.compute.hlsl", 1280, 720, m_srvHeap, m_renderTarget);
 
 	WaitForGPU();
 
@@ -540,7 +542,7 @@ void DXRenderManager::EndRender()
 	m_commandList->ResourceBarrier(static_cast<UINT>(preResolveBarriers.size()), preResolveBarriers.begin());
 
 	// Process compute shader
-	m_computeBuffer.PostProcess(m_commandList, m_srvHeap, m_renderTarget, m_renderTargets[m_frameIndex]);
+	m_computeBuffer->PostProcess(m_commandList, m_srvHeap, m_renderTarget, m_renderTargets[m_frameIndex]);
 
 	//m_commandList->ResolveSubresource(m_renderTargets[m_frameIndex].Get(), 0, m_renderTarget->GetMSAARenderTarget().Get(), 0, DXGI_FORMAT_R8G8B8A8_UNORM);
 

--- a/Engine/source/DXRenderManager.cpp
+++ b/Engine/source/DXRenderManager.cpp
@@ -539,18 +539,23 @@ void DXRenderManager::EndRender()
 	//OutputDebugStringA("EndRender: Entered.\n");
 
 	auto preResolveBarriers = {
-	CD3DX12_RESOURCE_BARRIER::Transition(m_renderTarget->GetMSAARenderTarget().Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RESOLVE_SOURCE),
-	//CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RESOLVE_DEST)
+		CD3DX12_RESOURCE_BARRIER::Transition(m_renderTarget->GetMSAARenderTarget().Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RESOLVE_SOURCE),
+		// @TODO Comment for compute shader use later
+		CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RESOLVE_DEST)
 	};
 	m_commandList->ResourceBarrier(static_cast<UINT>(preResolveBarriers.size()), preResolveBarriers.begin());
 
 	// Process compute shader
-	m_computeBuffer->PostProcess(m_commandList, m_srvHeap, m_renderTarget, m_renderTargets[m_frameIndex]);
+	// @TODO Uncomment for compute shader use later
+	//m_computeBuffer->PostProcess(m_commandList, m_srvHeap, m_renderTarget, m_renderTargets[m_frameIndex]);
 
-	//m_commandList->ResolveSubresource(m_renderTargets[m_frameIndex].Get(), 0, m_renderTarget->GetMSAARenderTarget().Get(), 0, DXGI_FORMAT_R8G8B8A8_UNORM);
+	// @TODO Comment for compute shader use later
+	m_commandList->ResolveSubresource(m_renderTargets[m_frameIndex].Get(), 0, m_renderTarget->GetMSAARenderTarget().Get(), 0, DXGI_FORMAT_R8G8B8A8_UNORM);
 
-	//auto postResolveBarrier = CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RESOLVE_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET);
-	//m_commandList->ResourceBarrier(1, &postResolveBarrier);
+	// @TODO Comment for compute shader use later
+	auto postResolveBarrier = CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RESOLVE_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET);
+	// @TODO Comment for compute shader use later
+	m_commandList->ResourceBarrier(1, &postResolveBarrier);
 
 	// ImGui Render
 	CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(m_frameIndex), m_rtvDescriptorSize);

--- a/Engine/source/DXRenderManager.cpp
+++ b/Engine/source/DXRenderManager.cpp
@@ -338,6 +338,9 @@ void DXRenderManager::OnResize(int width, int height)
 	m_renderTarget.reset();
 	m_renderTarget = std::make_unique<DXRenderTarget>(m_device, Engine::GetWindow().GetWindow());
 
+	// Recreate Compute Shader
+	m_computeBuffer->OnResize(m_device, width, height, m_srvHeap, m_renderTarget);
+
 	m_frameIndex = m_swapChain->GetCurrentBackBufferIndex();
 	//OutputDebugStringA("OnResize: Finished successfully.\n");
 


### PR DESCRIPTION
- Implemented compute shader support for DX12.

To test compute shader,
<img width="1621" height="675" alt="image" src="https://github.com/user-attachments/assets/7ebe1e45-3040-42c6-b7fb-a86b9e6c550e" />
Please follow instructions commented in DXRenderManager.cpp.

Result output should be the following:
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/b71d6541-faee-455c-8c60-28fe73dbfe38" />
which is inverted color output.